### PR TITLE
Add more assertions to remove more panics

### DIFF
--- a/with_assertions/src/collections/ring_buffer.rs
+++ b/with_assertions/src/collections/ring_buffer.rs
@@ -222,6 +222,7 @@ impl<T: Copy> queue::Queue<T> for RingBuffer<'_, T> {
                 while next_slot != self.tail {
                     self.ring[slot] = self.ring[next_slot];
                     slot = next_slot;
+                    assert_invariants!(self);
                     next_slot = (next_slot + 1) % len;
                 }
                 self.tail = slot;

--- a/with_assertions/src/collections/ring_buffer.rs
+++ b/with_assertions/src/collections/ring_buffer.rs
@@ -252,10 +252,6 @@ impl<T: Copy> queue::Queue<T> for RingBuffer<'_, T> {
         F: FnMut(&T) -> bool,
     {
         let len = self.ring.len();
-        unsafe {
-            // Tell LLVM/Rust that len > 0 for the rest of the function.
-            assert_unchecked(len > 0);
-        }
         assert_invariants!(self);
         // Index over the elements before the retain operation.
         let mut src = self.head;

--- a/with_assertions/src/main.rs
+++ b/with_assertions/src/main.rs
@@ -60,7 +60,7 @@ harness_fn!(call_remove_first_matching, |buf: &mut RingBuffer<i32>| {
 });
 
 harness_fn!(call_retain, |buf: &mut RingBuffer<i32>| {
-    black_box(buf.retain(|&x: &i32| black_box(x) % black_box(2) == 0));
+    black_box(buf.retain(|&x: &i32| black_box(x) * black_box(2) == 0));
 });
 
 harness_fn!(call_empty, |buf: &mut RingBuffer<i32>| {

--- a/without_assertions/src/main.rs
+++ b/without_assertions/src/main.rs
@@ -60,7 +60,7 @@ harness_fn!(call_remove_first_matching, |buf: &mut RingBuffer<i32>| {
 });
 
 harness_fn!(call_retain, |buf: &mut RingBuffer<i32>| {
-    black_box(buf.retain(|&x: &i32| black_box(x) % black_box(2) == 0));
+    black_box(buf.retain(|&x: &i32| black_box(x) * black_box(2) == 0));
 });
 
 harness_fn!(call_empty, |buf: &mut RingBuffer<i32>| {


### PR DESCRIPTION
Closes #11, to try and remove further panics through invoking our `assert_invariants` macro at the right places.